### PR TITLE
fix: missed enum conversion

### DIFF
--- a/Recademy.Api/Migrations/20201031172509_FixEntitiesEnums.Designer.cs
+++ b/Recademy.Api/Migrations/20201031172509_FixEntitiesEnums.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Recademy.Api;
 
 namespace Recademy.Api.Migrations
 {
     [DbContext(typeof(RecademyContext))]
-    partial class RecademyContextModelSnapshot : ModelSnapshot
+    [Migration("20201031172509_FixEntitiesEnums")]
+    partial class FixEntitiesEnums
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Recademy.Api/Migrations/20201031172509_FixEntitiesEnums.cs
+++ b/Recademy.Api/Migrations/20201031172509_FixEntitiesEnums.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Recademy.Api.Migrations
+{
+    public partial class FixEntitiesEnums : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "UserType",
+                table: "Users",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ReviewConclusion",
+                table: "ReviewResponses",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UserType",
+                table: "Users");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ReviewConclusion",
+                table: "ReviewResponses",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(string));
+        }
+    }
+}

--- a/Recademy.Api/RecademyContext.cs
+++ b/Recademy.Api/RecademyContext.cs
@@ -1,16 +1,31 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Recademy.Library.Models;
+using Recademy.Library.Types;
 
 namespace Recademy.Api
 {
     public class RecademyContext : DbContext
     {
+
         public RecademyContext(DbContextOptions options) : base(options)
         {
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            
+            modelBuilder
+                .Entity<ReviewResponse>()
+                .Property(reviewResponse => reviewResponse.ReviewConclusion)
+                .HasConversion(new EnumToStringConverter<ReviewConclusion>());
+
+            modelBuilder
+                .Entity<User>()
+                .Property(user => user.UserType)
+                .HasConversion(new EnumToStringConverter<UserType>());
+
             modelBuilder.Entity<UserSkill>()
                 .HasKey(bc => new { bc.UserId, bc.SkillName });
 
@@ -75,12 +90,9 @@ namespace Recademy.Api
         public DbSet<ReviewResponse> ReviewResponses { get; set; }
         public DbSet<ReviewRequest> ReviewRequests { get; set; }
         public DbSet<ProjectInfo> ProjectInfos { get; set; }
-
         public DbSet<UserSkill> UserSkills { get; set; }
         public DbSet<ProjectSkill> ProjectSkills { get; set; }
         public DbSet<ReviewResponseUpvote> ReviewResponseUpvotes { get; set; }
-
-
         public DbSet<Settings> Settings { get; set; }
     }
 }


### PR DESCRIPTION
Enum'ы чуть чуть поломали контекст. Для добавления Enum'a в EntityFramework необходим дополнительный преобразователь, которого не было

док: https://docs.microsoft.com/ru-ru/ef/core/modeling/value-conversions